### PR TITLE
Update Euphonic version check logic

### DIFF
--- a/+euphonic/private/euphonic_on.m
+++ b/+euphonic/private/euphonic_on.m
@@ -3,9 +3,6 @@ function euphonic_on()
 global horace_euphonic_interface_is_initialised;
 if isempty(horace_euphonic_interface_is_initialised) || ~horace_euphonic_interface_is_initialised
  
-    % Set number of openblas threads to 1 so it doesn't interfere with openmp
-    setenv('OPENBLAS_NUM_THREADS', '1');
-    
     % Sets library opening flag on Linux to load C modules immediately and to
     % force Matlab to use the math libraries of this module instead of its own.
     if ~ispc

--- a/+euphonic/private/verify_python_modules.m
+++ b/+euphonic/private/verify_python_modules.m
@@ -65,24 +65,32 @@ end
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-function ret = semver_compatible(astr, bstr)
-a = semver_split(astr);
-b = semver_split(bstr);
-if a(1) == b(1) && (a(2) > b(2) || (a(2)==b(2) && a(3)>=b(3)))
-  ret = true;
-else
+function ret = semver_compatible(ver_str, req_ver_str)
+  ver = semver_split(ver_str);
+  req_ver = semver_split(req_ver_str);
+
   ret = false;
-end
+  if ver.major == req_ver.major
+    if ver.minor > req_ver.minor
+      ret = true;
+    elseif ver.minor == req_ver.minor && ver.patch >= req_ver.patch
+      if isempty(req_ver.pre) || req_ver.pre == '>' && ~isempty(ver.extra)
+        ret = true;
+      end
+    end
+  end
+
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-function v = semver_split(str)
-rM   =       '^(?<major>0|[1-9]\d*)';
+function vs = semver_split(str)
+rM   =       '^(?<pre>.*?)(?<major>0|[1-9]\d*)';
 rMm  = [rM  '\.(?<minor>0|[1-9]\d*)'];
 rMmp = [rMm '\.(?<patch>0|[1-9]\d*)'];
+rMmpx = [rMmp '(?<extra>.*)$'];
 
-if regexp(str, rMmp)
-  vs = regexp(str, rMmp, 'names');
+if regexp(str, rMmpx)
+  vs = regexp(str, rMmpx, 'names');
 elseif regexp(str, rMm)
   vs = regexp(str, rMm , 'names');
   vs.patch = '0';
@@ -91,6 +99,4 @@ elseif regexp(str, rM)
   vs.minor = '0';
   vs.patch = '0';
 end
-
-v = structfun(@str2num, vs);
 end

--- a/+euphonic/private/verify_python_modules.m
+++ b/+euphonic/private/verify_python_modules.m
@@ -73,9 +73,13 @@ function ret = semver_compatible(ver_str, req_ver_str)
   if ver.major == req_ver.major
     if ver.minor > req_ver.minor
       ret = true;
-    elseif ver.minor == req_ver.minor && ver.patch >= req_ver.patch
-      if isempty(req_ver.pre) || req_ver.pre == '>' && ~isempty(ver.extra)
+    elseif ver.minor == req_ver.minor
+      if ver.patch > req_ver.patch
         ret = true;
+      elseif ver.patch == req_ver.patch
+        if isempty(req_ver.pre) || req_ver.pre == '>' && ~isempty(ver.extra)
+          ret = true;
+        end
       end
     end
   end
@@ -93,10 +97,12 @@ if regexp(str, rMmpx)
   vs = regexp(str, rMmpx, 'names');
 elseif regexp(str, rMm)
   vs = regexp(str, rMm , 'names');
-  vs.patch = '0';
 elseif regexp(str, rM)
   vs = regexp(str, rM  , 'names');
-  vs.minor = '0';
-  vs.patch = '0';
 end
+
+if ~isfield(vs, 'minor') vs.minor = '0', end
+if ~isfield(vs, 'patch') vs.patch = '0', end
+if ~isfield(vs, 'extra') vs.extra = '', end
+
 end

--- a/+euphonic/private/verify_python_modules.m
+++ b/+euphonic/private/verify_python_modules.m
@@ -101,8 +101,8 @@ elseif regexp(str, rM)
   vs = regexp(str, rM  , 'names');
 end
 
-if ~isfield(vs, 'minor') vs.minor = '0', end
-if ~isfield(vs, 'patch') vs.patch = '0', end
-if ~isfield(vs, 'extra') vs.extra = '', end
+if ~isfield(vs, 'minor') vs.minor = '0'; end
+if ~isfield(vs, 'patch') vs.patch = '0'; end
+if ~isfield(vs, 'extra') vs.extra = ''; end
 
 end

--- a/euphonic_version.py
+++ b/euphonic_version.py
@@ -11,8 +11,19 @@ def get_euphonic_version():
         update_dependencies.pull_euphonic_sqw_models()
     with open(req_file, 'r') as minreq:
         verstr = [req for req in minreq if 'euphonic' in req]
-    return verstr[0].split('=')[1].strip()
-
+        if len(verstr) != 1:
+            raise ValueError(
+                f'Incorrect number of euphonic versions in {req_file}')
+        else:
+            verstr = verstr[0]
+        if verstr.find('=') == -1:
+            # No '=', so is using unreleased version
+            if verstr.find('>') == -1:
+                raise ValueError(
+                    f'Unexpected euphonic version {verstr} in {req_file}')
+            return '>' + verstr.split('>')[1].strip()
+        else:
+            return verstr.split('=')[1].strip()
 
 def update_euphonic_version():
     curdir = os.path.dirname(os.path.abspath(__file__))

--- a/test/Jenkinsfile
+++ b/test/Jenkinsfile
@@ -105,7 +105,6 @@ pipeline {
                     dir('euphonic_sqw_models') {
                         if (isUnix()) {
                             sh """
-                                git submodule update --init
                                 module load conda/3 &&
                                 module load gcc &&
                                 export CC=gcc

--- a/test/Jenkinsfile
+++ b/test/Jenkinsfile
@@ -89,18 +89,20 @@ pipeline {
                 script {
 		    if (env.AGENT == 'sl7') {
                         setGitHubBuildStatus("pending", "Starting", "Linux")
-                    } else if (!isUnix()){
-                        checkout scm
-                        bat 'git submodule update --init'
-		    }
+                    }
                 }
 	    }
         }
 
         stage("Set up") {
             steps {
-	        dir('euphonic_sqw_models') {
-                    script {
+                script {
+                    if (isUnix()) {
+                        sh 'git submodule update --init'
+                    } else {
+                        bat 'git submodule update --init'
+                    }
+                    dir('euphonic_sqw_models') {
                         if (isUnix()) {
                             sh """
                                 git submodule update --init

--- a/test/Jenkinsfile
+++ b/test/Jenkinsfile
@@ -99,31 +99,33 @@ pipeline {
 
         stage("Set up") {
             steps {
-                script {
-                    if (isUnix()) {
-                        sh """
-                            git submodule update --init
-                            module load conda/3 &&
-                            module load gcc &&
-                            export CC=gcc
-                            conda config --append channels free &&
-                            conda create --name py python=3.6 -y &&
-                            conda activate py &&
-                            python -m pip install --upgrade --user pip &&
-                            python -m pip install numpy &&
-                            python euphonic_sqw_models/apply_requirements.py
-                        """
-                    } else {
-                        bat """
-                            CALL conda remove --name py_%MATLAB_VERSION% --all
-                            CALL conda create --name py_%MATLAB_VERSION% python=3.6 -y
-                            CALL conda activate py_%MATLAB_VERSION%
-                            python -m pip install --upgrade --user pip
-                            python -m pip install numpy
-                            python euphonic_sqw_models/apply_requirements.py
-                        """
-		    }
-                }
+	        dir('euphonic_sqw_models') {
+                    script {
+                        if (isUnix()) {
+                            sh """
+                                git submodule update --init
+                                module load conda/3 &&
+                                module load gcc &&
+                                export CC=gcc
+                                conda config --append channels free &&
+                                conda create --name py python=3.6 -y &&
+                                conda activate py &&
+                                python -m pip install --upgrade --user pip &&
+                                python -m pip install numpy &&
+                                python apply_requirements.py
+                            """
+                        } else {
+                            bat """
+                                CALL conda remove --name py_%MATLAB_VERSION% --all
+                                CALL conda create --name py_%MATLAB_VERSION% python=3.6 -y
+                                CALL conda activate py_%MATLAB_VERSION%
+                                python -m pip install --upgrade --user pip
+                                python -m pip install numpy
+                                python apply_requirements.py
+                            """
+                        }
+                    }
+		}
             }
         }
 

--- a/test/Jenkinsfile
+++ b/test/Jenkinsfile
@@ -102,6 +102,7 @@ pipeline {
                 script {
                     if (isUnix()) {
                         sh """
+                            git submodule update --init
                             module load conda/3 &&
                             module load gcc &&
                             export CC=gcc
@@ -110,8 +111,7 @@ pipeline {
                             conda activate py &&
                             python -m pip install --upgrade --user pip &&
                             python -m pip install numpy &&
-                            python -m pip install euphonic[phonopy_reader]
-                            git submodule update --init
+                            python euphonic_sqw_models/apply_requirements.py
                         """
                     } else {
                         bat """
@@ -120,7 +120,7 @@ pipeline {
                             CALL conda activate py_%MATLAB_VERSION%
                             python -m pip install --upgrade --user pip
                             python -m pip install numpy
-                            python -m pip install euphonic[phonopy_reader]
+                            python euphonic_sqw_models/apply_requirements.py
                         """
 		    }
                 }

--- a/test/Jenkinsfile
+++ b/test/Jenkinsfile
@@ -85,13 +85,13 @@ pipeline {
     stages {
 
         stage("Notify") {
-	    steps {
+            steps {
                 script {
-		    if (env.AGENT == 'sl7') {
+                    if (env.AGENT == 'sl7') {
                         setGitHubBuildStatus("pending", "Starting", "Linux")
                     }
                 }
-	    }
+            }
         }
 
         stage("Set up") {
@@ -127,27 +127,27 @@ pipeline {
                             """
                         }
                     }
-		}
+                }
             }
         }
 
         stage("Test") {
             steps {
-	        script {
-		    if (isUnix()) {
+                script {
+                    if (isUnix()) {
                         sh """
                             module load matlab/\$MATLAB_VERSION &&
                             module load conda/3 &&
                             cd test &&
                             matlab -nosplash -nodesktop -batch "run('run_tests.m')"
                         """
-		    } else {
+                    } else {
                         bat """
                             CALL conda activate py_%MATLAB_VERSION%
-			    cd test
-			    "C:\\Programming\\Matlab%MATLAB_VERSION%\\bin\\matlab.exe" -nosplash -nodesktop -wait -batch "run('run_tests.m')"
+                            cd test
+                            "C:\\Programming\\Matlab%MATLAB_VERSION%\\bin\\matlab.exe" -nosplash -nodesktop -wait -batch "run('run_tests.m')"
                         """
-		    }
+                    }
                 }
             }
         }
@@ -162,7 +162,7 @@ pipeline {
                 }
                 // the new .prj file's syntax seems to only work with R2019b
                 if (isUnix()) {
-    		        if (env.MATLAB_VERSION == 'R2019b') {
+                    if (env.MATLAB_VERSION == 'R2019b') {
                         sh """
                             module load matlab/\$MATLAB_VERSION &&
                             module load conda/3 &&
@@ -172,7 +172,7 @@ pipeline {
                         """
                         archiveArtifacts artifacts: 'mltbx/horace_euphonic_interface.mltbx'
                     }
-		        } else {
+                } else {
                         bat """
                             CALL conda activate py_%MATLAB_VERSION%
                             python -m pip install requests
@@ -181,27 +181,27 @@ pipeline {
                         """
                         archiveArtifacts artifacts: 'mltbx/horace_euphonic_interface.mltbx'
                 }
-		    }
+            }
         }
 
         unsuccessful {
-	    script {
+            script {
                 if (env.AGENT == 'sl7') {
                     setGitHubBuildStatus("failure", "Unsuccessful", "Linux")
                 }
-	    }
+            }
             script {
-	        if (isUnix()) {
+                if (isUnix()) {
                     def email = getGitCommitAuthorEmail()
-	        } else {
+                } else {
                     def email = getGitCommitAuthorEmailWindows()
-	        }
+                }
                 mail (
                     to: "$email",
                     subject: "Linux failed pipeline: ${env.JOB_BASE_NAME}",
                     body: "See ${env.BUILD_URL}"
                 )
-	    }
+            }
         }
 
         cleanup {


### PR DESCRIPTION
Updating module version checking logic to handle the `>x.y.z` syntax indicating that we're between versions, so we should build from master rather than use a release euphonic

I've created some master specific jobs Scientific-Linux-7-2018b etc. on Anvil (previously we only had Branch-Scientific-Linux-7-2018b which would build any branch) but they still appear to be passing because they're using the old pinned version of euphonic_sqw_models and testing against the 0.4.0 release version of Euphonic. Hopefully once we're building from master Euphonic these builds will fail as they should.

In our tests I wonder if we should be force updating to the latest main submodules or just using the pinned versions?