### PR TITLE
v0.2.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,7 @@
-`Unreleased <https://github.com/pace-neutrons/horace-euphonic-interface/compare/v0.1.0...HEAD>`_
+`Unreleased <https://github.com/pace-neutrons/horace-euphonic-interface/compare/v0.2.0...HEAD>`_
+----------
+
+`v0.2.0 <https://github.com/pace-neutrons/horace-euphonic-interface/compare/v0.1.0...v0.2.0>`_
 ----------
 
 There has been a major refactor, which means changes to how
@@ -6,11 +9,17 @@ Horace-Euphonic-Interface is installed. There are also major changes
 to how Euphonic is used, the API has been updated to make it more
 object-oriented.
 
+- Dependency changes:
+
+ - Euphonic version dependency increased to >=0.5.0
+
 - Installation changes:
+
  - Horace-euphonic-interface is now distributed as a Matlab toolbox (``.mltbx``)
    which is available in the `Matlab File Exchange <https://www.mathworks.com/matlabcentral/fileexchange/>`_ as an Add-On
 
 - Usage changes:
+
  - ``euphonic_sf`` has been removed
  - ``euphonic_on`` has been removed
  - Force constants are now a separate object (``ForceConstants``) rather than
@@ -19,6 +28,7 @@ object-oriented.
    passing these parameters to ``euphonic_sf``
  - The function handle to be passed to ``disp2sqw_eval`` is ``CoherentCrystal.horace_disp`` rather than ``euphonic_sf``
  - The ``dw_grid`` argument has been renamed to ``debye_waller_grid``
+ - ``fall_back_on_python`` argument has been removed as this has been removed in Euphonic
 
 For more detailed help see the `documentation <https://horace-euphonic-interface.readthedocs.io/en/latest/>`_
 

--- a/euphonic_version.py
+++ b/euphonic_version.py
@@ -1,11 +1,14 @@
 import os
 import fileinput
 
+from update_dependencies import update_submodules
 
 def get_euphonic_version():
+    update_submodules()
     # gets the required euphonic version from `min_requirements.txt` file
     curdir = os.path.dirname(os.path.abspath(__file__))
     req_file = os.path.join(curdir, 'euphonic_sqw_models', 'min_requirements.txt')
+
     if not os.path.isfile(req_file):
         import update_dependencies
         update_dependencies.pull_euphonic_sqw_models()

--- a/euphonic_version.py
+++ b/euphonic_version.py
@@ -4,14 +4,10 @@ import fileinput
 from update_dependencies import update_submodules
 
 def get_euphonic_version():
-    update_submodules()
+    update_submodules('euphonic_sqw_models')
     # gets the required euphonic version from `min_requirements.txt` file
     curdir = os.path.dirname(os.path.abspath(__file__))
     req_file = os.path.join(curdir, 'euphonic_sqw_models', 'min_requirements.txt')
-
-    if not os.path.isfile(req_file):
-        import update_dependencies
-        update_dependencies.pull_euphonic_sqw_models()
     with open(req_file, 'r') as minreq:
         verstr = [req for req in minreq if 'euphonic' in req]
         if len(verstr) != 1:

--- a/euphonic_version.py
+++ b/euphonic_version.py
@@ -26,7 +26,8 @@ def get_euphonic_version():
 
 def update_euphonic_version():
     curdir = os.path.dirname(os.path.abspath(__file__))
+    ver = get_euphonic_version()
     with fileinput.FileInput(curdir+'/+euphonic/private/required_modules.m', inplace=True) as reqmod:
         for line in reqmod:
             # FileInput redirect stdout to the file, for inplace replacement; end='' means don't add extra newlines
-            print(line.replace('TO_BE_DETERMINED', f'{get_euphonic_version()}'), end='')
+            print(line.replace('TO_BE_DETERMINED', f'{ver}'), end='')

--- a/euphonic_version.py
+++ b/euphonic_version.py
@@ -1,13 +1,13 @@
 import os
 import fileinput
 
-from update_dependencies import update_submodules
-
 def get_euphonic_version():
-    update_submodules('euphonic_sqw_models')
     # gets the required euphonic version from `min_requirements.txt` file
     curdir = os.path.dirname(os.path.abspath(__file__))
     req_file = os.path.join(curdir, 'euphonic_sqw_models', 'min_requirements.txt')
+    if not os.path.isfile(req_file):
+        from update_dependencies import update_submodules
+        update_submodules('euphonic_sqw_models')
     with open(req_file, 'r') as minreq:
         verstr = [req for req in minreq if 'euphonic' in req]
         if len(verstr) != 1:

--- a/release.py
+++ b/release.py
@@ -69,13 +69,13 @@ def release_github(test=True):
     with open('CHANGELOG.rst') as f:
         changelog = f.read()
     hor_eu_interface_ver = 'v' + __version__
-    changelog_ver = re.findall('`?(v\d+\.\d+\.\S+)\s', changelog)[0]
+    changelog_ver = re.findall('\n`(v\d+\.\d+\.\S+)\s', changelog)[0]
     if hor_eu_interface_ver != changelog_ver:
         raise Exception((
             f'VERSION and CHANGELOG.rst version mismatch!\n'
             f'VERSION: {hor_eu_interface_ver}\nCHANGELOG.rst: '
             f'{changelog_ver}'))
-    desc = re.search('`v\d+\.\d+\.\S+.*?^-+\n(.*)', changelog,
+    desc = re.search('`v\d+\.\d+\.\S+.*?^-+\n(.*)^`v', changelog,
                      re.DOTALL | re.MULTILINE).groups()[0].strip()
 
     payload = {

--- a/release.py
+++ b/release.py
@@ -14,8 +14,16 @@ __version__ = versioneer.get_version()
 def main():
     parser = get_parser()
     args = parser.parse_args()
-
     print(args)
+
+    if args.github:
+        args.create_toolbox = True
+
+    if args.create_toolbox:
+        update_dependencies.pull_light_wrapper()
+        update_dependencies.pull_euphonic_sqw_models()
+        create_mltbx()
+
     test = not args.notest
     if args.github:
         release_github(test)
@@ -33,6 +41,26 @@ def check_submodule_version(submodule):
         raise Exception(f'Submodule {submodule} is not a tagged (release) '
                         f'version. A release version of Horace-Euphonic-Interface '
                         f'should depend on release versions of its submodules')
+
+
+def create_mltbx():
+    import fileinput
+    # replace version string
+    version = __version__.split('+')[0] if '+' in __version__ else __version__  # Matlab only accepts numbers
+    with fileinput.FileInput('mltbx/horace_euphonic_interface.prj', inplace=True) as prj:
+        for line in prj:
+            # FileInput redirect stdout to the file, for inplace replacement; end='' means don't add extra newlines
+            print(line.replace('<param.version>1.0</param.version>', f'<param.version>{version}</param.version>'), end='')
+    euphonic_version.update_euphonic_version()
+    # shutil.copytree expects destination to not exist
+    for dest_folder in ['+light_python_wrapper', 'euphonic_sqw_models', '+euphonic']:
+        if os.path.isdir('mltbx/' + dest_folder): shutil.rmtree('mltbx/' + dest_folder)
+    shutil.copytree('light_python_wrapper/+light_python_wrapper', 'mltbx/+light_python_wrapper')
+    shutil.copytree('euphonic_sqw_models/euphonic_sqw_models', 'mltbx/euphonic_sqw_models/euphonic_sqw_models')
+    shutil.copytree('+euphonic', 'mltbx/+euphonic')
+    subprocess.run(['matlab', '-batch', 'create_mltbx'], cwd='mltbx')
+    print('.mltbx created')
+
 
 def release_github(test=True):
     submodules = ['light_python_wrapper', 'euphonic_sqw_models']
@@ -68,13 +96,8 @@ def release_github(test=True):
             headers={"Authorization": "token " + os.environ["GITHUB_TOKEN"]})
         print(response.text)
 
-    # Create a Matlab toolbox and upload it
-    update_dependencies.pull_light_wrapper()
-    update_dependencies.pull_euphonic_sqw_models()
-    create_mltbx()
-    if test:
-        print("Would upload mltx to github.")
-    else:
+    # Upload Matlab toolbox
+    if not test:
         upload_url = response.json().get('upload_url')
         response = requests.post(
             upload_url,
@@ -88,6 +111,11 @@ def release_github(test=True):
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        '--create-toolbox',
+        action='store_true',
+        help=('Create .mltbx file. This is automatically set to True if '
+              '--github is used'))
+    parser.add_argument(
         '--github',
         action='store_true',
         help='Release on Github')
@@ -97,23 +125,6 @@ def get_parser():
         help='Actually send/upload')
     return parser
 
-
-def create_mltbx():
-    import fileinput
-    # replace version string
-    version = __version__.split('+')[0] if '+' in __version__ else __version__  # Matlab only accepts numbers
-    with fileinput.FileInput('mltbx/horace_euphonic_interface.prj', inplace=True) as prj:
-        for line in prj:
-            # FileInput redirect stdout to the file, for inplace replacement; end='' means don't add extra newlines
-            print(line.replace('<param.version>1.0</param.version>', f'<param.version>{version}</param.version>'), end='')
-    euphonic_version.update_euphonic_version()
-    # shutil.copytree expects destination to not exist
-    for dest_folder in ['+light_python_wrapper', 'euphonic_sqw_models', '+euphonic']:
-        if os.path.isdir('mltbx/' + dest_folder): shutil.rmtree('mltbx/' + dest_folder)
-    shutil.copytree('light_python_wrapper/+light_python_wrapper', 'mltbx/+light_python_wrapper')
-    shutil.copytree('euphonic_sqw_models/euphonic_sqw_models', 'mltbx/euphonic_sqw_models/euphonic_sqw_models')
-    shutil.copytree('+euphonic', 'mltbx/+euphonic')
-    subprocess.run(['matlab', '-batch', 'create_mltbx'], cwd='mltbx')
 
 
 if __name__ == '__main__':

--- a/release.py
+++ b/release.py
@@ -7,7 +7,7 @@ import subprocess
 import shutil
 import versioneer
 import euphonic_version
-import update_dependencies
+from update_dependencies import update_submodules
 
 __version__ = versioneer.get_version()
 
@@ -16,12 +16,11 @@ def main():
     args = parser.parse_args()
     print(args)
 
+    update_submodules()
     if args.github:
         args.create_toolbox = True
 
     if args.create_toolbox:
-        update_dependencies.pull_light_wrapper()
-        update_dependencies.pull_euphonic_sqw_models()
         create_mltbx()
 
     test = not args.notest

--- a/release.py
+++ b/release.py
@@ -20,15 +20,31 @@ def main():
     if args.github:
         release_github(test)
 
+def check_submodule_version(submodule):
+    """
+    Check release version of Horace-Euphonic-Interface depends
+    on release versions of submodules
+    """
+    ret = subprocess.run('git tag --points-at HEAD',
+                         cwd=submodule,
+                         capture_output=True)
+    ver = ret.stdout.decode('utf-8').strip()
+    if ver == '':
+        raise Exception(f'Submodule {submodule} is not a tagged (release) '
+                        f'version. A release version of Horace-Euphonic-Interface '
+                        f'should depend on release versions of its submodules')
 
 def release_github(test=True):
+    submodules = ['light_python_wrapper', 'euphonic_sqw_models']
+    for submodule in submodules:
+        check_submodule_version(submodule)
+
     with open('CHANGELOG.rst') as f:
         changelog = f.read()
     hor_eu_interface_ver = 'v' + __version__
     changelog_ver = re.findall('`?(v\d+\.\d+\.\S+)\s', changelog)[0]
     if hor_eu_interface_ver != changelog_ver:
-        #raise Exception((
-        print((
+        raise Exception((
             f'VERSION and CHANGELOG.rst version mismatch!\n'
             f'VERSION: {hor_eu_interface_ver}\nCHANGELOG.rst: '
             f'{changelog_ver}'))

--- a/test/Jenkinsfile
+++ b/test/Jenkinsfile
@@ -162,7 +162,7 @@ pipeline {
                             module load conda/3 &&
                             conda activate py &&
                             python -m pip install requests
-                            python release.py --github
+                            python release.py --create-toolbox
                         """
                         archiveArtifacts artifacts: 'mltbx/horace_euphonic_interface.mltbx'
                     }
@@ -171,7 +171,7 @@ pipeline {
                             CALL conda activate py_%MATLAB_VERSION%
                             python -m pip install requests
                             setx PATH "%PATH%;C:\\Programming\\Matlab%MATLAB_VERSION%\\bin\\"
-                            python release.py --github
+                            python release.py --create-toolbox
                         """
                         archiveArtifacts artifacts: 'mltbx/horace_euphonic_interface.mltbx'
                 }

--- a/test/run_tests.m
+++ b/test/run_tests.m
@@ -1,8 +1,11 @@
 verify_test_data();
 % Updates the required euphonic versions
 curdir = split(fileparts(mfilename('fullpath')), filesep);
-append(py.sys.path, char(join(curdir(1:end-1), filesep)));
+repodir = char(join(curdir(1:end-1), filesep));
+disp(['Adding ', repodir, ' to Python path']);
+append(py.sys.path, repodir);
 py.euphonic_version.update_euphonic_version();
+
 res = runtests('test/EuphonicTest.m', 'Tag', 'integration');
 passed = [res.Passed];
 if ~all(passed)

--- a/test/verify_test_data.m
+++ b/test/verify_test_data.m
@@ -6,10 +6,12 @@ function verify_test_data()
     if exist([testdr{1} filesep 'nacl_T300.mat'], 'file')
         return
     end
+    disp(['Test data files not found in ', testdr{1}]);
     submod = join([curdir(1:end-1); {'euphonic_sqw_models'}], filesep);
     if ~exist([submod{1} filesep 'test' filesep 'expected_output'], 'dir')
-        websave('main.zip', ... 
-            'https://github.com/pace-neutrons/euphonic_sqw_models/archive/main.zip');
+        test_data_addr = 'https://github.com/pace-neutrons/euphonic_sqw_models/archive/main.zip';
+        disp(['Test data not found in ', submod{1}, ', downloading from ', test_data_addr]);
+        websave('main.zip', test_data_addr);
         unzip('main.zip', 'main');
         dd = dir('main');
         for ii = 1:numel(dd)
@@ -19,6 +21,7 @@ function verify_test_data()
             end
         end
     end
+    disp(['Copying test data from ', submod{1}]);
     copyfile(char(join({submod{1} 'test' 'expected_output' '*'}, filesep)), ...
         'expected_output');
 end

--- a/update_dependencies.py
+++ b/update_dependencies.py
@@ -1,17 +1,17 @@
 import os
-import io
 import zipfile
-import requests
 import shutil
 import subprocess
+from urllib.request import urlretrieve
 
 
 def pull_light_wrapper():
     # Checks if the light_python_wrapper submodule has been fetched. If not, get it from github
     if not os.path.isfile('light_python_wrapper/+light_python_wrapper/light_python_wrapper.m'):
-        gh_zip = 'https://github.com/pace-neutrons/light_python_wrapper/archive/master.zip'
-        zipdata = requests.get(gh_zip, stream=True)
-        zf = zipfile.ZipFile(io.BytesIO(zipdata.content))
+        zip_name = 'master.zip'
+        gh_zip = 'https://github.com/pace-neutrons/light_python_wrapper/archive/' + zip_name
+        urlretrieve(gh_zip, zip_name)
+        zf = zipfile.ZipFile(zip_name)
         zf.extractall('.')
         rtfolder = zf.infolist()[0].filename
         shutil.copytree(rtfolder+'/+light_python_wrapper', 'light_python_wrapper/+light_python_wrapper')
@@ -20,10 +20,10 @@ def pull_light_wrapper():
 def pull_euphonic_sqw_models():
     # Checks if the euphonic_sqw_models submodule has been fetched. If not, get it from github
     if not os.path.isfile('euphonic_sqw_models/euphonic_sqw_models/euphonic_wrapper.py'):
-        import zipfile, io
-        gh_zip = 'https://github.com/pace-neutrons/euphonic_sqw_models/archive/main.zip'
-        zipdata = requests.get(gh_zip, stream=True)
-        zf = zipfile.ZipFile(io.BytesIO(zipdata.content))
+        zip_name = 'main.zip'
+        gh_zip = 'https://github.com/pace-neutrons/euphonic_sqw_models/archive/' + zip_name
+        urlretrieve(gh_zip, zip_name)
+        zf = zipfile.ZipFile(zip_name)
         zf.extractall('.')
         rtfolder = zf.infolist()[0].filename
         shutil.copytree(rtfolder+'/euphonic_sqw_models', 'euphonic_sqw_models/euphonic_sqw_models')

--- a/update_dependencies.py
+++ b/update_dependencies.py
@@ -31,11 +31,16 @@ def pull_euphonic_sqw_models():
 
 
 def update_submodules(submodule=None):
+    curdir = os.path.dirname(os.path.abspath(__file__))
     submodules = {
             'euphonic_sqw_models':
-                {'required_path': 'euphonic_sqw_models/euphonic_sqw_models/euphonic_wrapper.py'},
+                {'required_path': os.path.join(
+                    curdir,
+                    os.path.join('euphonic_sqw_models', 'euphonic_sqw_models', 'euphonic_wrapper.py'))},
             'light_python_wrapper':
-                {'required_path': 'light_python_wrapper/+light_python_wrapper/light_python_wrapper.m'}}
+                {'required_path': os.path.join(
+                    curdir,
+                    os.path.join('light_python_wrapper', '+light_python_wrapper', 'light_python_wrapper.m'))}}
     if submodule is not None:
         submodules = {submodule: submodules[submodule]}
     for key, val in submodules.items():

--- a/update_dependencies.py
+++ b/update_dependencies.py
@@ -30,8 +30,19 @@ def pull_euphonic_sqw_models():
         shutil.copyfile(rtfolder+'/min_requirements.txt', 'euphonic_sqw_models/min_requirements.txt')
 
 
-def update_submodules():
-    cmd = 'git submodule update --init'
-    print(cmd)
-    ret = subprocess.run(cmd)
-    ret.check_returncode()
+def update_submodules(submodule=None):
+    submodules = {
+            'euphonic_sqw_models':
+                {'required_path': 'euphonic_sqw_models/euphonic_sqw_models/euphonic_wrapper.py'},
+            'light_python_wrapper':
+                {'required_path': 'light_python_wrapper/+light_python_wrapper/light_python_wrapper.m'}}
+    if submodule is not None:
+        submodules = {submodule: submodules[submodule]}
+    for key, val in submodules.items():
+        if not os.path.isfile(val['required_path']):
+            cmd = 'git submodule update --init ' + key
+            print(cmd)
+            ret = subprocess.run(cmd)
+            ret.check_returncode()
+        else:
+            print(f"{val['required_path']} already present, not updating {key}")

--- a/update_dependencies.py
+++ b/update_dependencies.py
@@ -3,6 +3,7 @@ import io
 import zipfile
 import requests
 import shutil
+import subprocess
 
 
 def pull_light_wrapper():
@@ -29,3 +30,8 @@ def pull_euphonic_sqw_models():
         shutil.copyfile(rtfolder+'/min_requirements.txt', 'euphonic_sqw_models/min_requirements.txt')
 
 
+def update_submodules():
+    cmd = 'git submodule update --init'
+    print(cmd)
+    ret = subprocess.run(cmd)
+    ret.check_returncode()


### PR DESCRIPTION
The `euphonic_sqw_models` submodule is currently pointing to the [v0.3.0_release branch](https://github.com/pace-neutrons/euphonic_sqw_models/tree/v0.3.0_release) for testing, but once https://github.com/pace-neutrons/euphonic_sqw_models/pull/2 is accepted and it's tagged and released I'll update it to point to the release tag

The main changes are:
- Updated changelog
- Added some more verbosity to `run_tests.m` and `verify_test_data.m`, its useful for CI, and better than quietly downloading zips!
- Changed from using `requests` in `pull_python_light_wrapper` to `urllib` as `requests` isn't included in the standard library
- Switched from using `pull_python_light_wrapper` etc. to `update_submodules` which uses `git submodule update` instead of downloading zips from master. Downloading the master zip may often not be the right thing to do as it might be different to the commit pointed to by the submodule, but I acknowledge this will only work if its still a git repository. Maybe there's a better solution? Do we need to check the submodules at all? I don't think the code actually gets called anywhere in the CI or release process, and people probably shouldn't be downloading the source code zip...
- Added `--create-toolbox` argument to `release.py`, as you can create a toolbox without wanting to upload it to github, and it makes more sense seeing `--create-toolbox` in the `Jenkinsfile` 

