### PR TITLE
Update sf units

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@
 
  - Euphonic version dependency increased from >=0.5.0 to >=0.6.0
 
+- Breaking changes:
+
+  - The default units of ``StructureFactor.structure_factors`` in Euphonic have been
+    changed from ``angstrom**2`` per unit cell to ``mbarn`` per sample atom, and are
+    now in absolute units including a previously omitted 1/2 factor. So the structure
+    factors produced by ``CoherentCrystal.horace_disp`` have increased by a factor of
+    ``1e11/(2*N_atoms)``
+
 - Other changes:
 
  - The ``eta_scale`` keyword argument to ``CoherentCrystal`` has been deprecated,

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -164,7 +164,7 @@ by ``CoherentCrystal.horace_disp``:
 
 .. code-block:: matlab
 
-  scale_factor = 1e12;
+  scale_factor = 2e2;
   effective_fwhm = 1;
 
   cut_sim = disp2sqw_eval(cut, @coh_model.horace_disp, {scale_factor}, effective_fwhm);
@@ -194,7 +194,7 @@ An example script simulating a simple cut is below:
 
 
   % Simulate
-  scale_factor = 1e12;
+  scale_factor = 2e2;
   effective_fwhm = 1;
   cut_sim = disp2sqw_eval(...
      cut, @coh_model.horace_disp, {scale_factor}, effective_fwhm);

--- a/test/EuphonicTest.m
+++ b/test/EuphonicTest.m
@@ -66,6 +66,14 @@ classdef EuphonicTest < EuphonicTestSuper
             sf_summed = sum_degenerate_modes(w_mat, sf_mat);
             expected_sf_summed = sum_degenerate_modes(w_mat, expected_sf_mat);
             bounds = AbsoluteTolerance(0.01) | RelativeTolerance(0.01);
+            % Temporary solution to ensure results have only changed by a
+            % scale factor before regenerating the test data
+            % Don't use near-zero values to get scaling as these can be
+            % unstable
+            idx = sf_summed > 1e-4;
+            scale = mean(sf_summed(idx)./expected_sf_summed(idx));
+            expected_sf_summed = expected_sf_summed*scale;
+
             testCase.verifyThat(sf_summed, ...
                 IsEqualTo(expected_sf_summed, 'within', bounds));
         end

--- a/test/EuphonicTest.m
+++ b/test/EuphonicTest.m
@@ -66,14 +66,6 @@ classdef EuphonicTest < EuphonicTestSuper
             sf_summed = sum_degenerate_modes(w_mat, sf_mat);
             expected_sf_summed = sum_degenerate_modes(w_mat, expected_sf_mat);
             bounds = AbsoluteTolerance(0.01) | RelativeTolerance(0.01);
-            % Temporary solution to ensure results have only changed by a
-            % scale factor before regenerating the test data
-            % Don't use near-zero values to get scaling as these can be
-            % unstable
-            idx = sf_summed > 1e-4;
-            scale = mean(sf_summed(idx)./expected_sf_summed(idx));
-            expected_sf_summed = expected_sf_summed*scale;
-
             testCase.verifyThat(sf_summed, ...
                 IsEqualTo(expected_sf_summed, 'within', bounds));
         end

--- a/test/EuphonicTest.m
+++ b/test/EuphonicTest.m
@@ -49,7 +49,7 @@ classdef EuphonicTest < EuphonicTestSuper
             import matlab.unittest.constraints.IsEqualTo
             import matlab.unittest.constraints.AbsoluteTolerance
             import matlab.unittest.constraints.RelativeTolerance
-            bounds = AbsoluteTolerance(5e-4) | RelativeTolerance(0.01);
+            bounds = AbsoluteTolerance(6e-4) | RelativeTolerance(0.01);
             testCase.verifyThat(w_mat, ...
                 IsEqualTo(expected_w_mat, 'within', bounds));
             % Ignore acoustic structure factors by setting to zero - their

--- a/test/EuphonicTestSuper.m
+++ b/test/EuphonicTestSuper.m
@@ -19,7 +19,7 @@ classdef EuphonicTestSuper < matlab.mock.TestCase
         bose = {missing, false};
         negative_e = {missing, true};
         conversion_mat =  {missing, (1/2)*[-1, 1, 1; 1, -1, 1; 1, 1, -1]};
-        lim = {missing, 1e-9};
+        lim = {missing, 1e2};
     end
 
     methods (TestClassSetup)
@@ -40,7 +40,7 @@ classdef EuphonicTestSuper < matlab.mock.TestCase
 
             opts = {};
             % Only add values to opts if they aren't missing
-            opts_keys = {'debye_waller_grid', 'bose', 'negative_e', 'conversion_mat'};
+            opts_keys = {'debye_waller_grid', 'bose', 'negative_e', 'conversion_mat', 'lim'};
             opts_values = {dw_grid, bose, negative_e, conversion_mat, lim};
             for i=1:length(opts_keys)
                 if ~ismissing(opts_values{i})

--- a/test/EuphonicTestSuper.m
+++ b/test/EuphonicTestSuper.m
@@ -40,8 +40,7 @@ classdef EuphonicTestSuper < matlab.mock.TestCase
 
             opts = {};
             % Only add values to opts if they aren't missing
-            opts_keys = {'debye_waller_grid', 'bose', 'negative_e', 'conversion_mat', ...
-                         'lim'};
+            opts_keys = {'debye_waller_grid', 'bose', 'negative_e', 'conversion_mat'};
             opts_values = {dw_grid, bose, negative_e, conversion_mat, lim};
             for i=1:length(opts_keys)
                 if ~ismissing(opts_values{i})


### PR DESCRIPTION
Updating as a result of https://github.com/pace-neutrons/Euphonic/pull/174. This updates the submodules, and also updates the test parameter `lim` `1e-9` -> `1e2` due to the new units. In the documentation the example `scale` parameter has also been updated `1e12` -> `2e2` as this is more in line with what would be used with the new units.

The submodule `euphonic_sqw_models` will need to be updated once https://github.com/pace-neutrons/euphonic_sqw_models/pull/4 is merged