### PR TITLE
Fix help tests

### DIFF
--- a/create_mltbx.py
+++ b/create_mltbx.py
@@ -1,0 +1,56 @@
+import os
+import re
+import subprocess
+import shutil
+import glob
+
+import versioneer
+import euphonic_version
+
+__version__ = versioneer.get_version()
+
+HELPDOCSTR = '\n' \
+    '    % Overloaded help command to display Python help in Matlab\n' \
+    '    % To use it, please type\n' \
+    '    %\n' \
+    '    % >> import euphonic.help\n' \
+    '    % >> help <topic>\n' \
+    '    %\n' \
+    '    % where <topic> is a Python class or method which has been wrapped for use in Matlab.\n' \
+    '    % If the topic is not wrapped, the normal Matlab help is displayed.\n' \
+
+def replace_matlab_docstring(filename, replacement_str):
+    with open(filename) as f:
+        txt = f.read()
+    cm = [m.start() for m in re.finditer(r'\n\s*%', txt)]
+    nl = [m.start() for m in re.finditer(r'\n', txt)]
+    idx = [cm[idx] for idx in range(len(cm)) if cm[idx] == nl[idx]]
+    newtxt = txt[:idx[0]] + replacement_str + txt[idx[-1]:]
+    with open(filename, 'w') as f:
+        f.write(newtxt)
+
+def create_mltbx():
+    import fileinput
+    # replace version string
+    version = __version__.split('+')[0] if '+' in __version__ else __version__  # Matlab only accepts numbers
+    with fileinput.FileInput('mltbx/horace_euphonic_interface.prj', inplace=True) as prj:
+        for line in prj:
+            # FileInput redirect stdout to the file, for inplace replacement; end='' means don't add extra newlines
+            print(line.replace('<param.version>1.0</param.version>', f'<param.version>{version}</param.version>'), end='')
+    euphonic_version.update_euphonic_version()
+    # shutil.copytree expects destination to not exist
+    for dest_folder in ['+light_python_wrapper', 'euphonic_sqw_models', '+euphonic']:
+        if os.path.isdir('mltbx/' + dest_folder): shutil.rmtree('mltbx/' + dest_folder)
+    shutil.copytree('light_python_wrapper/+light_python_wrapper', 'mltbx/+light_python_wrapper')
+    shutil.copytree('euphonic_sqw_models/euphonic_sqw_models', 'mltbx/euphonic_sqw_models/euphonic_sqw_models')
+    shutil.copytree('+euphonic', 'mltbx/+euphonic')
+    for fil in glob.glob('light_python_wrapper/helputils/*.m'): shutil.copy(fil, 'mltbx/+euphonic')
+    for fil in glob.glob('light_python_wrapper/helputils/private/*.m'): shutil.copy(fil, 'mltbx/+euphonic/private')
+    replace_matlab_docstring('mltbx/+euphonic/help.m', HELPDOCSTR)
+    replace_matlab_docstring('mltbx/+euphonic/doc.m', HELPDOCSTR.replace('help', 'doc'))
+    subprocess.run(['matlab', '-batch', 'create_mltbx'], cwd='mltbx')
+    print('.mltbx created')
+
+if __name__ == '__main__':
+    create_mltbx()
+

--- a/release.py
+++ b/release.py
@@ -6,9 +6,11 @@ import requests
 import subprocess
 import shutil
 import glob
+
 import versioneer
 import euphonic_version
 from update_dependencies import update_submodules
+from create_mltbx import create_mltbx
 
 __version__ = versioneer.get_version()
 
@@ -41,51 +43,6 @@ def check_submodule_version(submodule):
         raise Exception(f'Submodule {submodule} is not a tagged (release) '
                         f'version. A release version of Horace-Euphonic-Interface '
                         f'should depend on release versions of its submodules')
-
-
-HELPDOCSTR = '\n' \
-    '    % Overloaded help command to display Python help in Matlab\n' \
-    '    % To use it, please type\n' \
-    '    %\n' \
-    '    % >> import euphonic.help\n' \
-    '    % >> help <topic>\n' \
-    '    %\n' \
-    '    % where <topic> is a Python class or method which has been wrapped for use in Matlab.\n' \
-    '    % If the topic is not wrapped, the normal Matlab help is displayed.\n' \
-
-def replace_matlab_docstring(filename, replacement_str):
-    with open(filename) as f:
-        txt = f.read()
-    cm = [m.start() for m in re.finditer(r'\n\s*%', txt)]
-    nl = [m.start() for m in re.finditer(r'\n', txt)]
-    idx = [cm[idx] for idx in range(len(cm)) if cm[idx] == nl[idx]]
-    newtxt = txt[:idx[0]] + replacement_str + txt[idx[-1]:]
-    with open(filename, 'w') as f:
-        f.write(newtxt)
-
-
-def create_mltbx():
-    import fileinput
-    # replace version string
-    version = __version__.split('+')[0] if '+' in __version__ else __version__  # Matlab only accepts numbers
-    with fileinput.FileInput('mltbx/horace_euphonic_interface.prj', inplace=True) as prj:
-        for line in prj:
-            # FileInput redirect stdout to the file, for inplace replacement; end='' means don't add extra newlines
-            print(line.replace('<param.version>1.0</param.version>', f'<param.version>{version}</param.version>'), end='')
-    euphonic_version.update_euphonic_version()
-    # shutil.copytree expects destination to not exist
-    for dest_folder in ['+light_python_wrapper', 'euphonic_sqw_models', '+euphonic']:
-        if os.path.isdir('mltbx/' + dest_folder): shutil.rmtree('mltbx/' + dest_folder)
-    shutil.copytree('light_python_wrapper/+light_python_wrapper', 'mltbx/+light_python_wrapper')
-    shutil.copytree('euphonic_sqw_models/euphonic_sqw_models', 'mltbx/euphonic_sqw_models/euphonic_sqw_models')
-    shutil.copytree('+euphonic', 'mltbx/+euphonic')
-    for fil in glob.glob('light_python_wrapper/helputils/*.m'): shutil.copy(fil, 'mltbx/+euphonic')
-    for fil in glob.glob('light_python_wrapper/helputils/private/*.m'): shutil.copy(fil, 'mltbx/+euphonic/private')
-    replace_matlab_docstring('mltbx/+euphonic/help.m', HELPDOCSTR)
-    replace_matlab_docstring('mltbx/+euphonic/doc.m', HELPDOCSTR.replace('help', 'doc'))
-    subprocess.run(['matlab', '-batch', 'create_mltbx'], cwd='mltbx')
-    print('.mltbx created')
-
 
 def release_github(test=True):
     submodules = ['light_python_wrapper', 'euphonic_sqw_models']

--- a/test/Jenkinsfile
+++ b/test/Jenkinsfile
@@ -177,7 +177,9 @@ pipeline {
                                 conda activate \$CONDA_ENV_NAME &&
                                 export PYTHON_EX_PATH=`which python` &&
                                 module load matlab/R\$MATLAB_VERSION &&
-                                matlab -nosplash -nodesktop -batch "run_tests"
+                                conda install xorg-x11-server-xvfb-cos7-x86_64 --channel conda-forge &&
+                                xvfb-run -e /dev/stderr --server-args="-core -noreset -screen 0 640x480x24" --server-num=101 \
+                                    matlab -nosplash -batch "run_tests"
                             """
                         } else {
                             powershell '../PACE-jenkins-shared-library/powershell_scripts/execute_matlab_command.ps1 "run_tests"'

--- a/test/Jenkinsfile
+++ b/test/Jenkinsfile
@@ -178,8 +178,7 @@ pipeline {
                                 export PYTHON_EX_PATH=`which python` &&
                                 module load matlab/R\$MATLAB_VERSION &&
                                 conda install xorg-x11-server-xvfb-cos7-x86_64 --channel conda-forge &&
-                                xvfb-run -e /dev/stderr --server-args="-core -noreset -screen 0 640x480x24" --server-num=101 \
-                                    matlab -nosplash -batch "run_tests"
+                                xvfb-run -e /dev/stderr matlab -nosplash -batch "run_tests"
                             """
                         } else {
                             powershell '../PACE-jenkins-shared-library/powershell_scripts/execute_matlab_command.ps1 "run_tests"'

--- a/test/Jenkinsfile
+++ b/test/Jenkinsfile
@@ -128,7 +128,7 @@ pipeline {
             }
         }
 
-        stage("Set up") {
+        stage("Create mltbx and install Python modules") {
             steps {
                 script {
                     if (isUnix()) {
@@ -136,27 +136,32 @@ pipeline {
                     } else {
                         bat 'git submodule update --init'
                     }
-                    dir('euphonic_sqw_models') {
-                        if (isUnix()) {
-                            sh """
-                                module load conda/3 &&
-                                module load gcc &&
-                                conda create --name \$CONDA_ENV_NAME python=3.6 -y &&
-                                conda activate \$CONDA_ENV_NAME &&
-                                python -m pip install --upgrade pip &&
-                                python -m pip install numpy &&
-                                python apply_requirements.py
-                            """
-                        } else {
-                            powershell '../PACE-jenkins-shared-library/powershell_scripts/create_conda_environment.ps1'
-                            bat """
-                                CALL "%VS2019_VCVARSALL%" x86_amd64
-                                CALL conda activate %CONDA_ENV_NAME%
-                                python -m pip install --upgrade pip
-                                python -m pip install numpy
-                                python apply_requirements.py
-                            """
-                        }
+                    if (isUnix()) {
+                        sh """
+                            module load conda/3 &&
+                            module load gcc &&
+                            module load matlab/R\$MATLAB_VERSION &&
+                            conda create --name \$CONDA_ENV_NAME python=3.6 -y &&
+                            conda activate \$CONDA_ENV_NAME &&
+                            python -m pip install --upgrade pip &&
+                            python -m pip install requests numpy &&
+                            python create_mltbx.py &&
+                            cd euphonic_sqw_models &&
+                            python apply_requirements.py
+                        """
+                    } else {
+                        powershell 'PACE-jenkins-shared-library/powershell_scripts/create_conda_environment.ps1'
+                        bat """
+                            setx PATH "%PATH%;C:\\Programming\\MatlabR%MATLAB_VERSION%\\bin\\"
+                            CALL "%VS2019_VCVARSALL%" x86_amd64
+                            CALL conda activate %CONDA_ENV_NAME%
+                            python -m pip install --upgrade pip
+                            python -m pip install requests
+                            python create_mltbx.py
+                            python -m pip install numpy
+                            cd euphonic_sqw_models
+                            python apply_requirements.py
+                        """
                     }
                 }
             }
@@ -215,27 +220,7 @@ pipeline {
         // Always publish toolbox - useful for debugging and integration testing
         always {
             script {
-                // the new .prj file's syntax seems to only work with R2019b
-                if (isUnix()) {
-                    if (env.MATLAB_VERSION == '2019b') {
-                        sh """
-                            module load matlab/R\$MATLAB_VERSION &&
-                            module load conda/3 &&
-                            conda activate \$CONDA_ENV_NAME &&
-                            python -m pip install requests
-                            python release.py --create-toolbox
-                        """
-                        archiveArtifacts artifacts: 'mltbx/horace_euphonic_interface.mltbx'
-                    }
-                } else {
-                    bat """
-                        CALL conda activate %CONDA_ENV_NAME%
-                        python -m pip install requests
-                        setx PATH "%PATH%;C:\\Programming\\MatlabR%MATLAB_VERSION%\\bin\\"
-                        python release.py --create-toolbox
-                    """
-                    archiveArtifacts artifacts: 'mltbx/horace_euphonic_interface.mltbx'
-                }
+                archiveArtifacts artifacts: 'mltbx/horace_euphonic_interface.mltbx'
             }
         }
         cleanup {

--- a/test/run_tests.m
+++ b/test/run_tests.m
@@ -33,15 +33,9 @@ end
 % Ensure test data from euphonic_sqw_models is present
 verify_test_data();
 
-% Updates the required euphonic versions
-curdir = split(fileparts(mfilename('fullpath')), filesep);
-repodir = char(join(curdir(1:end-1), filesep));
-disp(['Adding ', repodir, ' to Python path']);
-append(py.sys.path, repodir);
-py.euphonic_version.update_euphonic_version();
-
-res = runtests("test/", 'Tag', 'integration');
-res2 = runtests("test/", 'Tag', 'help');
+% Run tests
+res = runtests(pwd, 'Tag', 'integration');
+res2 = runtests(pwd, 'Tag', 'help');
 passed = [res.Passed res2.Passed];
 if ~all(passed)
     quit(1);

--- a/test/run_tests.m
+++ b/test/run_tests.m
@@ -13,9 +13,17 @@ catch ME
   end
 end
 
-% Add horace-euphonic-interface to Path
-addpath('..')
-addpath('../light_python_wrapper')
+% Install horace-euphonic-interface mltbx
+toolboxes = matlab.addons.toolbox.installedToolboxes;
+for i = 1:length(toolboxes)
+  if strcmp(toolboxes(i).Name, 'horace_euphonic_interface')
+    matlab.addons.toolbox.uninstallToolbox(toolboxes(i));
+    break;
+  end
+end
+matlab.addons.toolbox.installToolbox(...
+  ['..' filesep 'mltbx' filesep 'horace_euphonic_interface.mltbx']);
+matlab.addons.toolbox.installedToolboxes
 
 % Set flags on Linux to avoid segfault with libraries
 if ~ispc


### PR DESCRIPTION
Addresses #18 

I've decided to disable the Matlab 2018 builds, as they aren't compatible with the .prj syntax we're using. Rather than spend time trying to fix it, I thought I'd just disable them as we'll soon move to supporting newer versions instead, and pace-integration tests that the toolbox can at least be installed with Matlab 2018 and run with integration tests so I think we're covered there.

The Windows build is working: https://anvil.softeng-support.ac.uk/jenkins/job/PACE-neutrons/job/horace-euphonic-interface/job/Branch-Windows-10-2019b/
However, the Linux build is failing: https://anvil.softeng-support.ac.uk/jenkins/job/PACE-neutrons/job/horace-euphonic-interface/job/Branch-Scientific-Linux-7-2019b/

```
Running EuphonicHelpTest
.
================================================================================
Error occurred in EuphonicHelpTest/run_euphonic_doc_tests and it did not run to completion.
    ---------
    Error ID:
    ---------
    'MATLAB:doc:UnsupportedPlatform'
    --------------
    Error Details:
    --------------
    Error using doc (line 49)
    DOC is not currently available.
    
    Error in EuphonicHelpTest/run_euphonic_doc_tests/eval_doc (line 43)
                    eval(cmd);
    
    Error in EuphonicHelpTest/run_euphonic_doc_tests (line 56)
                txt_fc_noimport = eval_doc('doc euphonic.ForceConstants');
================================================================================
.
Done EuphonicHelpTest
__________

Failure Summary:

     Name                                     Failed  Incomplete  Reason(s)
    ========================================================================
     EuphonicHelpTest/run_euphonic_doc_tests    X         X       Errored.
```
Any ideas why doc won't work on the Linux nodes? (I think they're running on Docker containers, or at least they used to)