### PR TITLE
Warn instead of error on version incompatibility

### DIFF
--- a/+euphonic/private/verify_python_modules.m
+++ b/+euphonic/private/verify_python_modules.m
@@ -37,8 +37,9 @@ catch ME
 end
 
 if ~semver_compatible(pyv, min_py_ver)
-  error('euphonic_horace_interface:verify_python_modules:pythonVersion',...
-        'euphonic-horace-interface requires Python >= %s', min_py_ver);
+  warning(['euphonic-horace-interface requires Python >=%s, but you '...
+	   'have version %s so things might not work as expected'],...
+	  min_py_ver, pyv);
 end
 
 for mod = fieldnames(mods)'
@@ -60,8 +61,9 @@ for mod = fieldnames(mods)'
         warning(['Required version of %s is "TO_BE_DETERMINED", are you ',...
                  'using a development version of Horace-Euphonic-Interface?'], mod{:})
     elseif ~semver_compatible(installed_ver, mods.(mod{:}))
-      error('euphonic_horace_interface:verify_python_modules:modIncompatibleVersion',...
-            '%s >= %s required but %s present',mod{:}, mods.(mod{:}), installed_ver);
+      warning(['horace-euphonic-interface requires %s >= %s, but you '...
+	       'have %s, so things might not work as expected.'],...
+	      mod{:}, mods.(mod{:}), installed_ver);
     end
 end
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@
 
   - ``n_threads`` will now automatically be converted to an integer (using e.g.
     ``int32(4)`` is no longer needed)
+  - Warn rather than error if the incorrect Python version or Python module
+    versions are used
 
 - Bug fixes:
 


### PR DESCRIPTION
I think raising an error when the incorrect version of Python/Euphonic are used is a bit harsh (especially the Python version, just because we're not officially testing on that version any more doesn't mean it won't work). e.g. the Python version on IDAaaS is still 3.6 and is arbitrarily stopping Horace-Euphonic-Interface from working.